### PR TITLE
fix: convert static-only classes to functions

### DIFF
--- a/apps/frontend/src/app/features/settings/bos/clipboard.bo.ts
+++ b/apps/frontend/src/app/features/settings/bos/clipboard.bo.ts
@@ -2,52 +2,51 @@
  * Business Object for clipboard operations
  * Following SRP: Separates clipboard logic from components
  */
-export class ClipboardBo {
-  /**
-   * Copy text to clipboard and return success status
-   * @param text - Text to copy
-   * @returns Promise<boolean> - true if copy succeeded
-   */
-  static async copyToClipboard(text: string): Promise<boolean> {
-    try {
-      await navigator.clipboard.writeText(text);
-      return true;
-    } catch {
-      return false;
-    }
+
+/**
+ * Copy text to clipboard and return success status
+ * @param text - Text to copy
+ * @returns Promise<boolean> - true if copy succeeded
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    return false;
   }
+}
 
-  /**
-   * Copy text to clipboard with temporary success message
-   * @param text - Text to copy
-   * @param label - Label to display in success message
-   * @param duration - Duration to show message in ms (default: 3000)
-   * @returns Promise with success message or null
-   */
-  static async copyWithMessage(
-    text: string,
-    label: string,
-    duration = 3000
-  ): Promise<{ message: string | null; clear: () => void }> {
-    const success = await ClipboardBo.copyToClipboard(text);
+/**
+ * Copy text to clipboard with temporary success message
+ * @param text - Text to copy
+ * @param label - Label to display in success message
+ * @param duration - Duration to show message in ms (default: 3000)
+ * @returns Promise with success message or null
+ */
+export async function copyWithMessage(
+  text: string,
+  label: string,
+  duration = 3000
+): Promise<{ message: string | null; clear: () => void }> {
+  const success = await copyToClipboard(text);
 
-    if (!success) {
-      return {
-        message: null,
-        clear: () => {
-          /* no-op */
-        },
-      };
-    }
-
-    const message = `${label} copied to clipboard`;
-    const timeoutId = setTimeout(() => {
-      /* no-op */
-    }, duration);
-
+  if (!success) {
     return {
-      message,
-      clear: () => clearTimeout(timeoutId),
+      message: null,
+      clear: () => {
+        /* no-op */
+      },
     };
   }
+
+  const message = `${label} copied to clipboard`;
+  const timeoutId = setTimeout(() => {
+    /* no-op */
+  }, duration);
+
+  return {
+    message,
+    clear: () => clearTimeout(timeoutId),
+  };
 }

--- a/apps/frontend/src/app/features/settings/bos/license.bo.ts
+++ b/apps/frontend/src/app/features/settings/bos/license.bo.ts
@@ -4,161 +4,160 @@ import { LicenseTier } from '../models/license.model';
  * Business Object for license display logic
  * Following SRP: Separates license presentation logic from components
  */
-export class LicenseBo {
-  /**
-   * Get CSS class for license tier badge
-   */
-  static getTierBadgeClass(tier: LicenseTier): string {
-    switch (tier) {
-      case LicenseTier.FREE:
-        return 'tier-badge tier-free';
-      case LicenseTier.PATREON:
-      case LicenseTier.PATREON_SUPPORTER:
-        return 'tier-badge tier-patreon';
-      case LicenseTier.PATREON_PLUS:
-        return 'tier-badge tier-patreon-plus';
-      case LicenseTier.PATREON_PRO:
-        return 'tier-badge tier-patreon-pro';
-      case LicenseTier.PATREON_ULTIMATE:
-        return 'tier-badge tier-patreon-ultimate';
-      case LicenseTier.COMMERCIAL_STARTER:
-        return 'tier-badge tier-commercial-starter';
-      case LicenseTier.COMMERCIAL_PRO:
-        return 'tier-badge tier-commercial-pro';
-      case LicenseTier.COMMERCIAL_ENTERPRISE:
-        return 'tier-badge tier-commercial-enterprise';
-      default:
-        return 'tier-badge';
-    }
-  }
 
-  /**
-   * Get display name for license tier
-   */
-  static getTierDisplayName(tier: LicenseTier): string {
-    switch (tier) {
-      case LicenseTier.FREE:
-        return 'Free';
-      case LicenseTier.PATREON:
-      case LicenseTier.PATREON_SUPPORTER:
-        return 'Supporter';
-      case LicenseTier.PATREON_PLUS:
-        return 'Plus';
-      case LicenseTier.PATREON_PRO:
-        return 'Pro';
-      case LicenseTier.PATREON_ULTIMATE:
-        return 'Ultimate';
-      case LicenseTier.COMMERCIAL_STARTER:
-        return 'Commercial Starter';
-      case LicenseTier.COMMERCIAL_PRO:
-        return 'Commercial Pro';
-      case LicenseTier.COMMERCIAL_ENTERPRISE:
-        return 'Enterprise';
-      default:
-        return tier;
-    }
+/**
+ * Get CSS class for license tier badge
+ */
+export function getTierBadgeClass(tier: LicenseTier): string {
+  switch (tier) {
+    case LicenseTier.FREE:
+      return 'tier-badge tier-free';
+    case LicenseTier.PATREON:
+    case LicenseTier.PATREON_SUPPORTER:
+      return 'tier-badge tier-patreon';
+    case LicenseTier.PATREON_PLUS:
+      return 'tier-badge tier-patreon-plus';
+    case LicenseTier.PATREON_PRO:
+      return 'tier-badge tier-patreon-pro';
+    case LicenseTier.PATREON_ULTIMATE:
+      return 'tier-badge tier-patreon-ultimate';
+    case LicenseTier.COMMERCIAL_STARTER:
+      return 'tier-badge tier-commercial-starter';
+    case LicenseTier.COMMERCIAL_PRO:
+      return 'tier-badge tier-commercial-pro';
+    case LicenseTier.COMMERCIAL_ENTERPRISE:
+      return 'tier-badge tier-commercial-enterprise';
+    default:
+      return 'tier-badge';
   }
+}
 
-  /**
-   * Get tier price for display
-   */
-  static getTierPrice(tier: LicenseTier): string {
-    switch (tier) {
-      case LicenseTier.FREE:
-        return 'Free';
-      case LicenseTier.PATREON:
-      case LicenseTier.PATREON_SUPPORTER:
-        return '$3/mo';
-      case LicenseTier.PATREON_PLUS:
-        return '$5/mo';
-      case LicenseTier.PATREON_PRO:
-        return '$10/mo';
-      case LicenseTier.PATREON_ULTIMATE:
-        return '$20/mo';
-      case LicenseTier.COMMERCIAL_STARTER:
-        return '$49/mo';
-      case LicenseTier.COMMERCIAL_PRO:
-        return '$149/mo';
-      case LicenseTier.COMMERCIAL_ENTERPRISE:
-        return 'Contact';
-      default:
-        return '';
-    }
+/**
+ * Get display name for license tier
+ */
+export function getTierDisplayName(tier: LicenseTier): string {
+  switch (tier) {
+    case LicenseTier.FREE:
+      return 'Free';
+    case LicenseTier.PATREON:
+    case LicenseTier.PATREON_SUPPORTER:
+      return 'Supporter';
+    case LicenseTier.PATREON_PLUS:
+      return 'Plus';
+    case LicenseTier.PATREON_PRO:
+      return 'Pro';
+    case LicenseTier.PATREON_ULTIMATE:
+      return 'Ultimate';
+    case LicenseTier.COMMERCIAL_STARTER:
+      return 'Commercial Starter';
+    case LicenseTier.COMMERCIAL_PRO:
+      return 'Commercial Pro';
+    case LicenseTier.COMMERCIAL_ENTERPRISE:
+      return 'Enterprise';
+    default:
+      return tier;
   }
+}
 
-  /**
-   * Check if tier is a Patreon tier
-   */
-  static isPatreonTier(tier: LicenseTier): boolean {
-    return tier.startsWith('PATREON');
+/**
+ * Get tier price for display
+ */
+export function getTierPrice(tier: LicenseTier): string {
+  switch (tier) {
+    case LicenseTier.FREE:
+      return 'Free';
+    case LicenseTier.PATREON:
+    case LicenseTier.PATREON_SUPPORTER:
+      return '$3/mo';
+    case LicenseTier.PATREON_PLUS:
+      return '$5/mo';
+    case LicenseTier.PATREON_PRO:
+      return '$10/mo';
+    case LicenseTier.PATREON_ULTIMATE:
+      return '$20/mo';
+    case LicenseTier.COMMERCIAL_STARTER:
+      return '$49/mo';
+    case LicenseTier.COMMERCIAL_PRO:
+      return '$149/mo';
+    case LicenseTier.COMMERCIAL_ENTERPRISE:
+      return 'Contact';
+    default:
+      return '';
   }
+}
 
-  /**
-   * Check if tier is a commercial tier
-   */
-  static isCommercialTier(tier: LicenseTier): boolean {
-    return tier.startsWith('COMMERCIAL');
-  }
+/**
+ * Check if tier is a Patreon tier
+ */
+export function isPatreonTier(tier: LicenseTier): boolean {
+  return tier.startsWith('PATREON');
+}
 
-  /**
-   * Get tier order for comparison (higher = better)
-   */
-  static getTierOrder(tier: LicenseTier): number {
-    const order: Record<LicenseTier, number> = {
-      [LicenseTier.FREE]: 0,
-      [LicenseTier.PATREON]: 1,
-      [LicenseTier.PATREON_SUPPORTER]: 1,
-      [LicenseTier.PATREON_PLUS]: 2,
-      [LicenseTier.PATREON_PRO]: 3,
-      [LicenseTier.PATREON_ULTIMATE]: 4,
-      [LicenseTier.COMMERCIAL_STARTER]: 5,
-      [LicenseTier.COMMERCIAL_PRO]: 6,
-      [LicenseTier.COMMERCIAL_ENTERPRISE]: 7,
-    };
-    return order[tier] ?? 0;
-  }
+/**
+ * Check if tier is a commercial tier
+ */
+export function isCommercialTier(tier: LicenseTier): boolean {
+  return tier.startsWith('COMMERCIAL');
+}
 
-  /**
-   * Check if targetTier is an upgrade from currentTier
-   */
-  static isUpgrade(currentTier: LicenseTier, targetTier: LicenseTier): boolean {
-    return LicenseBo.getTierOrder(targetTier) > LicenseBo.getTierOrder(currentTier);
-  }
+/**
+ * Get tier order for comparison (higher = better)
+ */
+export function getTierOrder(tier: LicenseTier): number {
+  const order: Record<LicenseTier, number> = {
+    [LicenseTier.FREE]: 0,
+    [LicenseTier.PATREON]: 1,
+    [LicenseTier.PATREON_SUPPORTER]: 1,
+    [LicenseTier.PATREON_PLUS]: 2,
+    [LicenseTier.PATREON_PRO]: 3,
+    [LicenseTier.PATREON_ULTIMATE]: 4,
+    [LicenseTier.COMMERCIAL_STARTER]: 5,
+    [LicenseTier.COMMERCIAL_PRO]: 6,
+    [LicenseTier.COMMERCIAL_ENTERPRISE]: 7,
+  };
+  return order[tier] ?? 0;
+}
 
-  /**
-   * Get tier icon class
-   */
-  static getTierIcon(tier: LicenseTier): string {
-    switch (tier) {
-      case LicenseTier.FREE:
-        return 'fa fa-gift';
-      case LicenseTier.PATREON:
-      case LicenseTier.PATREON_SUPPORTER:
-      case LicenseTier.PATREON_PLUS:
-      case LicenseTier.PATREON_PRO:
-      case LicenseTier.PATREON_ULTIMATE:
-        return 'fab fa-patreon';
-      case LicenseTier.COMMERCIAL_STARTER:
-      case LicenseTier.COMMERCIAL_PRO:
-        return 'fa fa-building';
-      case LicenseTier.COMMERCIAL_ENTERPRISE:
-        return 'fa fa-crown';
-      default:
-        return 'fa fa-key';
-    }
-  }
+/**
+ * Check if targetTier is an upgrade from currentTier
+ */
+export function isUpgrade(currentTier: LicenseTier, targetTier: LicenseTier): boolean {
+  return getTierOrder(targetTier) > getTierOrder(currentTier);
+}
 
-  /**
-   * Mask license key for display
-   */
-  static formatLicenseKeyDisplay(licenseKey: string, revealed: boolean): string {
-    return revealed ? licenseKey : '****-****-****-****';
+/**
+ * Get tier icon class
+ */
+export function getTierIcon(tier: LicenseTier): string {
+  switch (tier) {
+    case LicenseTier.FREE:
+      return 'fa fa-gift';
+    case LicenseTier.PATREON:
+    case LicenseTier.PATREON_SUPPORTER:
+    case LicenseTier.PATREON_PLUS:
+    case LicenseTier.PATREON_PRO:
+    case LicenseTier.PATREON_ULTIMATE:
+      return 'fab fa-patreon';
+    case LicenseTier.COMMERCIAL_STARTER:
+    case LicenseTier.COMMERCIAL_PRO:
+      return 'fa fa-building';
+    case LicenseTier.COMMERCIAL_ENTERPRISE:
+      return 'fa fa-crown';
+    default:
+      return 'fa fa-key';
   }
+}
 
-  /**
-   * Mask API key for display
-   */
-  static formatApiKeyDisplay(apiKey: string, revealed: boolean): string {
-    return revealed ? apiKey : '**********************';
-  }
+/**
+ * Mask license key for display
+ */
+export function formatLicenseKeyDisplay(licenseKey: string, revealed: boolean): string {
+  return revealed ? licenseKey : '****-****-****-****';
+}
+
+/**
+ * Mask API key for display
+ */
+export function formatApiKeyDisplay(apiKey: string, revealed: boolean): string {
+  return revealed ? apiKey : '**********************';
 }

--- a/apps/frontend/src/app/features/settings/tabs/license-tab.component.ts
+++ b/apps/frontend/src/app/features/settings/tabs/license-tab.component.ts
@@ -11,7 +11,13 @@ import {
 import { ActivatedRoute } from '@angular/router';
 import { TranslocoModule } from '@ngneat/transloco';
 import { catchError, forkJoin, of } from 'rxjs';
-import { LicenseBo } from '../bos/license.bo';
+import {
+  getTierBadgeClass,
+  getTierDisplayName,
+  getTierIcon,
+  getTierPrice,
+  isUpgrade,
+} from '../bos/license.bo';
 import type {
   ActivateLicense,
   License,
@@ -91,7 +97,7 @@ import { LicenseService } from '../services/license.service';
             <div class="tier-info">
               <i
                 [class]="
-                  LicenseBo.getTierIcon(
+                  getTierIcon(
                     capabilities()?.tier || LicenseTier.FREE
                   )
                 "
@@ -99,19 +105,19 @@ import { LicenseService } from '../services/license.service';
               <div>
                 <span
                   [class]="
-                    LicenseBo.getTierBadgeClass(
+                    getTierBadgeClass(
                       capabilities()?.tier || LicenseTier.FREE
                     )
                   "
                 >
                   {{
-                    LicenseBo.getTierDisplayName(
+                    getTierDisplayName(
                       capabilities()?.tier || LicenseTier.FREE
                     )
                   }}
                 </span>
                 <span class="price-tag">{{
-                  LicenseBo.getTierPrice(
+                  getTierPrice(
                     capabilities()?.tier || LicenseTier.FREE
                   )
                 }}</span>
@@ -367,7 +373,7 @@ import { LicenseService } from '../services/license.service';
                       [disabled]="stripeLoading()"
                     >
                       {{
-                        LicenseBo.isUpgrade(
+                        isUpgrade(
                           capabilities()?.tier || LicenseTier.FREE,
                           tier.id
                         )
@@ -1148,7 +1154,13 @@ export class LicenseTabComponent implements OnInit {
   }>;
 
   LicenseTier = LicenseTier;
-  readonly LicenseBo = LicenseBo;
+
+  // Expose functions to template
+  getTierBadgeClass = getTierBadgeClass;
+  getTierDisplayName = getTierDisplayName;
+  getTierIcon = getTierIcon;
+  getTierPrice = getTierPrice;
+  isUpgrade = isUpgrade;
 
   commercialTiers: LicenseTierInfo[] = [
     {


### PR DESCRIPTION
## Summary

Refactors `ClipboardBo` and `LicenseBo` from classes with only static methods to module-level functions following modern JS/TS best practices.

## Changes

- **clipboard.bo.ts**: Converted `ClipboardBo` class to `copyToClipboard()` and `copyWithMessage()` functions
- **license.bo.ts**: Converted `LicenseBo` class to individual functions:
  - `getTierBadgeClass()`, `getTierDisplayName()`, `getTierPrice()`
  - `isPatreonTier()`, `isCommercialTier()`, `getTierOrder()`, `isUpgrade()`
  - `getTierIcon()`, `formatLicenseKeyDisplay()`, `formatApiKeyDisplay()`
- **license-tab.component.ts**: Updated imports and template references to use new function names

## Why

Lint rule `noStaticOnlyClass` flagged these as anti-patterns. Modern TypeScript prefers module-level functions over classes with only static methods.

## Testing

- Lint passes (frontend: 0 errors, 14 warnings)
- Build passes (backend + frontend)
- Tests pass (pre-existing failures unrelated to this change)

## Related

Closes #12